### PR TITLE
New approach to adding new messages to make the error go away

### DIFF
--- a/contracts/Messaging.sol
+++ b/contracts/Messaging.sol
@@ -12,7 +12,6 @@ contract Messaging {
         string receiver_key;
         address sender;
         string sender_key;
-        uint256 messagesIndex;
     }
 
     struct Message {
@@ -33,8 +32,7 @@ contract Messaging {
             _receiver,
             _receiver_key,
             msg.sender,
-            _sender_key,
-            messagesIndex++
+            _sender_key
         );
 
         return threadCount;
@@ -54,9 +52,7 @@ contract Messaging {
                 _receiver_key
             );
 
-            Thread memory thread = threads[new_thread_id];
-
-            messages[thread.messagesIndex].push(
+            messages[new_thread_id].push(
                 Message(_receiver, _uri, block.timestamp)
             );
         } else {
@@ -67,7 +63,7 @@ contract Messaging {
                 "Only the receiver & sender can reply to the messages."
             );
 
-            messages[thread.messagesIndex].push(
+            messages[thread.thread_id].push(
                 Message(_receiver, _uri, block.timestamp)
             );
         }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -10,10 +10,10 @@ module.exports = {
   networks: {
     ropsten: {
       url: process.env.INFURA_URL,
-      accounts: [`0x${process.env.PRIVATE_KEY}`]
-    }
+      accounts: [`0x${process.env.PRIVATE_KEY}`],
+    },
   },
   etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY
-  }
+    apiKey: process.env.ETHERSCAN_API_KEY,
+  },
 };


### PR DESCRIPTION
## New Approach
- A mapping `messages` of `(uint256 => Message[])` to keep track of messages in a thread.
- The `uint256` corresponds to the `thread_id` in the `Thread` struct. 

## Example
So, if you had a thread which had the `thread_id` of `5`. 
To access the messages of that thread, you would access the `messages` mapping with `5`(`thread_id`) as the index -> `messages[thread_id]`